### PR TITLE
Xdg fixes

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -24,6 +24,7 @@ Terminal=false
 Type=Application
 Categories=Network;Application;
 Icon=${pkgname}.png
+MimeType=x-scheme-handler/around;
 EOL
 }
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -19,7 +19,7 @@ prepare() {
 [Desktop Entry]
 Name=Around
 Comment=Around.co linux client
-Exec="/opt/${pkgname}/${_appimage}" %U
+Exec=/opt/${pkgname}/${_appimage} %U
 Terminal=false
 Type=Application
 Categories=Network;Application;


### PR DESCRIPTION
I'm giving Manjaro/i3 a try, and had to do some setup to be able to login because the `around://` links were opened by random web browsers.

In addition to the changes of this PR, I also ran these commands:
```
xdg-mime default around.desktop x-scheme-handler/around
xdg-settings set default-url-scheme-handler around around.desktop
update-desktop-database
```
I'm not sure if these should be included in the build though.